### PR TITLE
Prevent code snippets from overlapping the profile picture

### DIFF
--- a/personal_website/components/floating-code-background.tsx
+++ b/personal_website/components/floating-code-background.tsx
@@ -74,7 +74,7 @@ export default function FloatingCodeBackground() {
         exclusionZoneRef.current = {
           centerX: rect.left + rect.width / 2,
           centerY: rect.top + scrollY + rect.height / 2,
-          radius: Math.max(rect.width, rect.height) / 2 + 20 // Add padding
+          radius: Math.max(rect.width, rect.height) / 2 // Exact radius of profile picture
         }
       }
     }


### PR DESCRIPTION
- Implemented an exclusion zone around the profile picture to prevent code snippets and other UI elements from overlapping.
- Refined the exclusion zone radius to match the profile picture boundary by removing unnecessary padding.

[v0 Session](https://v0.app/chat/uXhQaiCM9I5)